### PR TITLE
spotless

### DIFF
--- a/.github/workflows/Build.yaml
+++ b/.github/workflows/Build.yaml
@@ -16,6 +16,11 @@ jobs:
     timeout-minutes: 90
 
     steps:
+      - name: Checkout su/_main
+        uses: actions/checkout@v3
+        with:
+          ref: "su/_main"
+
       - name: Checkout
         uses: actions/checkout@v3
 

--- a/gradle/init.gradle.kts
+++ b/gradle/init.gradle.kts
@@ -12,6 +12,8 @@
  *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *   See the License for the specific language governing permissions and
  *   limitations under the License.
+ *
+ *   Modified by Jay Bobzin for StandUp! sample application
  */
 
 val ktlintVersion = "0.48.1"
@@ -31,7 +33,9 @@ initscript {
 rootProject {
     subprojects {
         apply<com.diffplug.gradle.spotless.SpotlessPlugin>()
+        // only check changes from _main
         extensions.configure<com.diffplug.gradle.spotless.SpotlessExtension> {
+            ratchetFrom("origin/su/_main")
             kotlin {
                 target("**/*.kt")
                 targetExclude("**/build/**/*.kt")

--- a/standup/app/src/main/kotlin/com/jaybobzin/standup/nowin/app/StandupActivity.kt
+++ b/standup/app/src/main/kotlin/com/jaybobzin/standup/nowin/app/StandupActivity.kt
@@ -1,5 +1,4 @@
 /* Copyright 2023 Jay Bobzin SPDX-License-Identifier: Apache-2.0 */
-
 package com.jaybobzin.standup.nowin.app
 
 import android.os.Bundle
@@ -31,4 +30,3 @@ class StandupActivity : ComponentActivity() {
         }
     }
 }
-

--- a/standup/app/src/main/kotlin/com/jaybobzin/standup/nowin/app/StandupApplication.kt
+++ b/standup/app/src/main/kotlin/com/jaybobzin/standup/nowin/app/StandupApplication.kt
@@ -3,5 +3,4 @@ package com.jaybobzin.standup.nowin.app
 
 import android.app.Application
 
-class StandupApplication : Application() { }
-
+class StandupApplication : Application()

--- a/standup/app/src/main/kotlin/com/jaybobzin/standup/nowin/app/StandupViewModel.kt
+++ b/standup/app/src/main/kotlin/com/jaybobzin/standup/nowin/app/StandupViewModel.kt
@@ -1,5 +1,4 @@
 /* Copyright 2023 Jay Bobzin SPDX-License-Identifier: Apache-2.0 */
-
 package com.jaybobzin.standup.nowin.app
 
 import androidx.lifecycle.ViewModel
@@ -7,25 +6,22 @@ import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.SharingStarted
-import kotlinx.coroutines.flow.SharingStarted.Companion
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.stateIn
 import javax.inject.Inject
 
 @HiltViewModel
-class StandupViewModel @Inject constructor( ) : ViewModel() {
+class StandupViewModel @Inject constructor() : ViewModel() {
 
     val countdownFlow: StateFlow<Int?> = flow {
         for (i in 3 downTo 0) {
             emit(i)
-            delay(2000)  // delay for 2 seconds
+            delay(2000) // delay for 2 seconds
         }
     }.stateIn(
         initialValue = null,
         scope = viewModelScope,
         started = SharingStarted.WhileSubscribed(),
     )
-
-
 }

--- a/standup/app/src/main/res/drawable/ic_su_launcher_fg.xml
+++ b/standup/app/src/main/res/drawable/ic_su_launcher_fg.xml
@@ -1,3 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2023 Jay Bobzin SPDX-License-Identifier: Apache-2.0 -->
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="108dp"
     android:height="108dp"

--- a/standup/app/src/main/res/drawable/ic_su_launcher_mono.xml
+++ b/standup/app/src/main/res/drawable/ic_su_launcher_mono.xml
@@ -1,3 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2023 Jay Bobzin SPDX-License-Identifier: Apache-2.0 -->
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="108dp"
     android:height="108dp"


### PR DESCRIPTION
`./gradlew spotlessApply --init-script gradle/init.gradle.kts --no-configuration-cache`

Modify to compare against su/_main

The major diffs this excludes are due to the update in the copyright header being different.